### PR TITLE
cvv.py: Don't fail when MANIFEST.MF isn't utf-8 encoded

### DIFF
--- a/src/javatoolkit/cvv.py
+++ b/src/javatoolkit/cvv.py
@@ -100,7 +100,12 @@ class CVVMagic:
             pass
         else:
             with manifest:
-                lines = [line.decode('utf-8').rstrip() for line in manifest.readlines()]
+                def decode_line(line: bytes) -> str:
+                    # The Manifest spec requires that the file is utf-8 encoded.
+                    # Unfortunately, stuff like the maven-jar-plugin can generate
+                    # an invalid manifest when it blindly copies the author name
+                    return line.decode('utf-8', 'replace').rstrip('\r\n')
+                lines = [decode_line(line) for line in manifest.readlines()]
                 is_multirelease = 'Multi-Release: true' in lines
 
         invalid_version_dirs: set[str] = set()

--- a/src/test/res/maven-generated-manifest.mf
+++ b/src/test/res/maven-generated-manifest.mf
@@ -1,0 +1,169 @@
+Manifest-Version: 1.0
+Created-By: Maven JAR Plugin 3.4.0
+Multi-Release: true
+Build-Jdk-Spec: 21
+Specification-Title: Maven Artifact Resolver API
+Specification-Version: 1.9
+Specification-Vendor: The Apache Software Foundation
+Implementation-Title: Maven Artifact Resolver API
+Implementation-Version: 1.9.22
+Implementation-Vendor: The Apache Software Foundation
+Automatic-Module-Name: org.apache.maven.resolver
+Bundle-Description: The application programming interface for the reposi
+ tory system.
+Bundle-Developers: khmarbaise;email="khmarbaise@apache.org";name="Karl H
+ einz Marbaise";roles="PMC Chair";timezone="+1",aheritier;email="aheriti
+ er@apache.org";name="Arnaud Héritier";roles="PMC Member";timezone="+1"
+ ,andham;email="andham@apache.org";name="Anders Hammar";roles="PMC Membe
+ r";timezone="+1",baerrach;email="baerrach@apache.org";name="Barrie Trel
+ oar";roles="PMC Member";timezone="Australia/Adelaide",bimargulies;email
+ ="bimargulies@apache.org";name="Benson Margulies";roles="PMC Member";ti
+ mezone="America/New_York",bmarwell;email="bmarwell@apache.org";name="Be
+ njamin Marwell";organization=ASF;roles="PMC Member";timezone="Europe/Be
+ rlin",brianf;email="brianf@apache.org";name="Brian Fox";organization=So
+ natype;roles="PMC Member";timezone=-5,cstamas;email="cstamas@apache.org
+ ";name="Tamas Cservenak";roles="PMC Member";timezone="+1",dennisl;email
+ ="dennisl@apache.org";name="Dennis Lundberg";organization=ASF;roles="PM
+ C Member";timezone="+1",dkulp;email="dkulp@apache.org";name="Daniel Kul
+ p";organization=ASF;roles="PMC Member";timezone=-5,evenisse;email="even
+ isse@apache.org";name="Emmanuel Venisse";organization=ASF;roles="PMC Me
+ mber";timezone="+1",gboue;email="gboue@apache.org";name="Guillaume Bou�
+ �";roles="PMC Member";timezone="Europe/Paris",gnodet;email="gnodet@apac
+ he.org";name="Guillaume Nodet";organization="Red Hat";roles="PMC Member
+ ";timezone="Europe/Paris",henning;email="henning@apache.org";name="Henn
+ ing Schmiedehausen";organization=ASF;roles="PMC Member";timezone="Ameri
+ ca/Los_Angeles",hboutemy;email="hboutemy@apache.org";name="Hervé Boute
+ my";organization=ASF;roles="PMC Member";timezone="Europe/Paris",ifedore
+ nko;email="igor@ifedorenko.com";name="Igor Fedorenko";organization=Sona
+ type;roles="PMC Member";timezone=-5,jvanzyl;email="jason@maven.org";nam
+ e="Jason van Zyl";roles="PMC Member";timezone=-5,krosenvold;email="kros
+ envold@apache.org";name="Kristian Rosenvold";roles="PMC Member";timezon
+ e="+1",kwin;email="kwin@apache.org";name="Konrad Windszus";organization
+ ="Cognizant Netcentric";roles="PMC Member";timezone="Europe/Berlin",mkl
+ eint;name="Milos Kleint";roles="PMC Member",mthmulders;email="mthmulder
+ s@apache.org";name="Maarten Mulders";organization="Info Support";roles=
+ "PMC Member";timezone="Europe/Amsterdam",olamy;email="olamy@apache.org"
+ ;name="Olivier Lamy";roles="PMC Member";timezone="Australia/Brisbane",m
+ ichaelo;email="michaelo@apache.org";name="Michael Osipov";roles="PMC Me
+ mber";timezone="Europe/Berlin",rfscholte;email="rfscholte@apache.org";n
+ ame="Robert Scholte";roles="PMC Member";timezone="Europe/Amsterdam",rgo
+ ers;email="rgoers@apache.org";name="Ralph Goers";organization=Intuit;ro
+ les="PMC Member";timezone=-8,sjaranowski;email="sjaranowski@apache.org"
+ ;name="Slawomir Jaranowski";roles="PMC Member";timezone="Europe/Warsaw"
+ ,stephenc;email="stephenc@apache.org";name="Stephen Connolly";roles="PM
+ C Member";timezone=0,slachiewicz;email="slachiewicz@apache.org";name="S
+ ylwester Lachiewicz";roles="PMC Member";timezone="Europe/Warsaw",strube
+ rg;email="struberg@apache.org";name="Mark Struberg";roles="PMC Member",
+ tibordigana;email="tibordigana@apache.org";name="Tibor Digaňa";roles="
+ PMC Member";timezone="Europe/Bratislava",vsiveton;email="vsiveton@apach
+ e.org";name="Vincent Siveton";organization=ASF;roles="PMC Member";timez
+ one=-5,wfay;email="wfay@apache.org";name="Wayne Fay";organization=ASF;r
+ oles="PMC Member";timezone=-6,adangel;email="adangel@apache.org";name="
+ Andreas Dangel";roles=Committer;timezone="Europe/Berlin",bdemers;email=
+ "bdemers@apache.org";name="Brian Demers";organization=Sonatype;roles=Co
+ mmitter;timezone=-5,bellingard;name="Fabrice Bellingard";roles=Committe
+ r,bentmann;email="bentmann@apache.org";name="Benjamin Bentmann";organiz
+ ation=Sonatype;roles=Committer;timezone="+1",chrisgwarp;email="chrisgwa
+ rp@apache.org";name="Chris Graham";roles=Committer;timezone="Australia/
+ Melbourne",dantran;email="dantran@apache.org";name="Dan Tran";roles=Com
+ mitter;timezone=-8,dbradicich;email="dbradicich@apache.org";name="Damia
+ n Bradicich";organization=Sonatype;roles=Committer;timezone=-5,brett;em
+ ail="brett@apache.org";name="Brett Porter";organization=ASF;roles=Commi
+ tter;timezone="+10",dfabulich;email="dfabulich@apache.org";name="Daniel
+  Fabulich";roles=Committer;timezone=-8,eolivelli;email="eolivelli@apach
+ e.org";name="Enrico Olivelli";organization=Diennea;roles=Committer;time
+ zone="Europe/Rome",fgiust;email="fgiust@apache.org";name="Fabrizio Gius
+ tina";organization=openmind;roles=Committer;timezone="+1",godin;email="
+ godin@apache.org";name="Evgeny Mandrikov";organization=SonarSource;role
+ s=Committer;timezone="+3",handyande;email="handyande@apache.org";name="
+ Andrew Williams";roles=Committer;timezone=0,imod;email="imod@apache.org
+ ";name="Dominik Bartholdi";roles=Committer;timezone="Europe/Zurich",jje
+ nsen;name="Jeff Jensen";roles=Committer,ltheussl;email="ltheussl@apache
+ .org";name="Lukas Theussl";roles=Committer;timezone="+1",markh;email="m
+ arkh@apache.org";name="Mark Hobson";roles=Committer;timezone=0,martinka
+ nters;email="martinkanters@apache.org";name="Martin Kanters";organizati
+ on=JPoint;roles=Committer;timezone="Europe/Amsterdam",mauro;name="Mauro
+  Talevi";roles=Committer,mfriedenhagen;email="mfriedenhagen@apache.org"
+ ;name="Mirko Friedenhagen";roles=Committer;timezone="+1",mmoser;email="
+ mmoser@apache.org";name="Manfred Moser";roles=Committer;timezone=-8,nic
+ olas;name="Nicolas de Loof";roles=Committer,oching;name="Maria Odea B. 
+ Ching";roles=Committer,pgier;email="pgier@apache.org";name="Paul Gier";
+ organization="Red Hat";roles=Committer;timezone=-6,ptahchiev;email="pta
+ hchiev@apache.org";name="Petar Tahchiev";roles=Committer;timezone="+2",
+ rafale;email="rafale@apache.org";name="Raphaël Piéroni";organization=
+ Dexem;roles=Committer;timezone="+1",schulte;email="schulte@apache.org";
+ name="Christian Schulte";roles=Committer;timezone="Europe/Berlin",snico
+ ll;email="snicoll@apache.org";name="Stephane Nicoll";roles=Committer;ti
+ mezone="+1",simonetripodi;email="simonetripodi@apache.org";name="Simone
+  Tripodi";roles=Committer;timezone="+1",sor;email="sor@apache.org";name
+ ="Christian Stein";roles=Committer;timezone="Europe/Berlin",tchemit;ema
+ il="tchemit@apache.org";name="Tony Chemit";organization=CodeLutin;roles
+ =Committer;timezone="Europe/Paris",vmassol;email="vmassol@apache.org";n
+ ame="Vincent Massol";organization=ASF;roles=Committer;timezone="+1",elh
+ aro;email="elharo@apache.org";name="Elliotte Rusty Harold";roles=Commit
+ ter;timezone="America/New_York",agudian;email="agudian@apache.org";name
+ ="Andreas Gudian";roles=Emeritus;timezone="Europe/Berlin",aramirez;name
+ ="Allan Q. Ramirez";roles=Emeritus,bayard;name="Henri Yandell";roles=Em
+ eritus,carlos;email="carlos@apache.org";name="Carlos Sanchez";organizat
+ ion=ASF;roles=Emeritus;timezone="+1",chrisjs;name="Chris Stevenson";rol
+ es=Emeritus,dblevins;name="David Blevins";roles=Emeritus,dlr;name="Dani
+ el Rall";roles=Emeritus,epunzalan;email="epunzalan@apache.org";name="Ed
+ win Punzalan";roles=Emeritus;timezone=-8,felipeal;name="Felipe Leme";ro
+ les=Emeritus,jdcasey;email="jdcasey@apache.org";name="John Casey";organ
+ ization=ASF;roles=Emeritus;timezone=-6,jmcconnell;email="jmcconnell@apa
+ che.org";name="Jesse McConnell";organization=ASF;roles=Emeritus;timezon
+ e=-6,joakime;email="joakime@apache.org";name="Joakim Erdfelt";organizat
+ ion=ASF;roles=Emeritus;timezone=-5,jruiz;email="jruiz@apache.org";name=
+ "Johnny Ruiz III";roles=Emeritus,jstrachan;name="James Strachan";roles=
+ Emeritus,jtolentino;email="jtolentino@apache.org";name="Ernesto Tolenti
+ no Jr.";organization=ASF;roles=Emeritus;timezone="+8",kenney;email="ken
+ ney@apache.org";name="Kenney Westerhof";organization=Neonics;roles=Emer
+ itus;timezone="+1",mperham;email="mperham@gmail.com";name="Mike Perham"
+ ;organization=IBM;roles=Emeritus;timezone=-6,ogusakov;name="Oleg Gusako
+ v";roles=Emeritus,pschneider;email="pschneider@gmail.com";name="Patrick
+  Schneider";roles=Emeritus;timezone=-6,rinku;name="Rahul Thakur";roles=
+ Emeritus,shinobu;name="Shinobu Kuwai";roles=Emeritus,smorgrav;name="Tor
+ bjorn Eikli Smorgrav";roles=Emeritus,trygvis;email="trygvis@apache.org"
+ ;name="Trygve Laugstol";organization=ASF;roles=Emeritus;timezone="+1",w
+ smoak;email="wsmoak@apache.org";name="Wendy Smoak";roles=Emeritus;timez
+ one=-7
+Bundle-DocURL: https://maven.apache.org/resolver/maven-resolver-api/
+Bundle-License: "Apache-2.0";link="https://www.apache.org/licenses/LICEN
+ SE-2.0.txt"
+Bundle-ManifestVersion: 2
+Bundle-Name: Maven Artifact Resolver API
+Bundle-SCM: url="https://github.com/apache/maven-resolver/tree/maven-res
+ olver-1.9.22/maven-resolver-api",connection="scm:git:https://gitbox.apa
+ che.org/repos/asf/maven-resolver.git/maven-resolver-api",developer-conn
+ ection="scm:git:https://gitbox.apache.org/repos/asf/maven-resolver.git/
+ maven-resolver-api",tag="maven-resolver-1.9.22"
+Bundle-SymbolicName: org.apache.maven.resolver.api
+Bundle-Vendor: The Apache Software Foundation
+Bundle-Version: 1.9.22
+Export-Package: org.eclipse.aether;uses:="org.eclipse.aether.artifact,or
+ g.eclipse.aether.collection,org.eclipse.aether.deployment,org.eclipse.a
+ ether.installation,org.eclipse.aether.metadata,org.eclipse.aether.repos
+ itory,org.eclipse.aether.resolution,org.eclipse.aether.transfer,org.ecl
+ ipse.aether.transform";version="1.9.22",org.eclipse.aether.artifact;ver
+ sion="1.9.22",org.eclipse.aether.collection;uses:="org.eclipse.aether,o
+ rg.eclipse.aether.artifact,org.eclipse.aether.graph,org.eclipse.aether.
+ repository,org.eclipse.aether.version";version="1.9.22",org.eclipse.aet
+ her.deployment;uses:="org.eclipse.aether,org.eclipse.aether.artifact,or
+ g.eclipse.aether.metadata,org.eclipse.aether.repository";version="1.9.2
+ 2",org.eclipse.aether.graph;uses:="org.eclipse.aether.artifact,org.ecli
+ pse.aether.repository,org.eclipse.aether.version";version="1.9.22",org.
+ eclipse.aether.installation;uses:="org.eclipse.aether,org.eclipse.aethe
+ r.artifact,org.eclipse.aether.metadata";version="1.9.22",org.eclipse.ae
+ ther.metadata;uses:="org.eclipse.aether";version="1.9.22",org.eclipse.a
+ ether.repository;uses:="org.eclipse.aether,org.eclipse.aether.artifact,
+ org.eclipse.aether.metadata";version="1.9.22",org.eclipse.aether.resolu
+ tion;uses:="org.eclipse.aether,org.eclipse.aether.artifact,org.eclipse.
+ aether.collection,org.eclipse.aether.graph,org.eclipse.aether.metadata,
+ org.eclipse.aether.repository,org.eclipse.aether.version";version="1.9.
+ 22",org.eclipse.aether.transfer;uses:="org.eclipse.aether,org.eclipse.a
+ ether.artifact,org.eclipse.aether.metadata,org.eclipse.aether.repositor
+ y";version="1.9.22",org.eclipse.aether.transform;uses:="org.eclipse.aet
+ her.artifact";version="1.9.22",org.eclipse.aether.version;uses:="org.ec
+ lipse.aether";version="1.9.22"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+


### PR DESCRIPTION
Use the UTF-8 replacement character rather then raising and exception when encountering invalid unicode in MANIFEST.MF, which is against the standard yet some programs like the maven-jar-plugin embed the author's name literally without properly encoding it first.

Closes: https://bugs.gentoo.org/952052